### PR TITLE
update dockerfile build command: cmd -> entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN npm install --production
 
 COPY . .
 
-CMD [ "npm", "run", "build" ]
+ENTRYPOINT [ "npm", "run", "build" ]
 
 CMD [ "npm", "run", "start:prod" ]


### PR DESCRIPTION
CMD로 빌드 명령과 실행 명령을 각각 선언하니 도커 허브 이미지를 풀 받아 컨테이너를 실행할 때 빌드가 생략되는 것을 확인했다.

컨테이너 실행 시 빌드할 수 있게 CMD를 ENTRYPOINT로 변경했다.