### PR TITLE
remove production option when run npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 COPY ["package.json", "package-lock.json*", "./"]
 
-RUN npm install --production
+RUN npm install
 
 COPY . .
 


### PR DESCRIPTION
이제 빌드 명령은 실행하는데 `nest`를 찾지 못하는 것을 보면 production 옵션이 `devDependencies` 패키지를 설치하지 않는 것이 아닌지 의심된다. 옵션을 지우고 시도한다.