### PR TITLE
Docker NODE_ENV 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 # syntax=docker/dockerfile:1
 
 FROM node:16.13.1
-ENV NODE_ENV=production
 
 WORKDIR /app
 
 COPY ["package.json", "package-lock.json*", "./"]
 
-RUN npm install --production
-
-RUN npm install -g @nestjs/cli
+RUN npm install
 
 COPY . .
 


### PR DESCRIPTION
실행은 NODE_ENV `production`이면 좋겠는데 `.ts` 파일 빌드 과정에서 불편함이 있다.

빌드 후 환경 변수를 지정할 수도 있을까?